### PR TITLE
Add forceRetry and processingDoneCompleter.

### DIFF
--- a/lib/src/smart_job.dart
+++ b/lib/src/smart_job.dart
@@ -71,6 +71,8 @@ class SmartJob {
   JobFailureCallback? onFailure;
   JobRetryCallback? onRetry;
 
+  bool isExecuting = false;
+
   bool get hasRemainingRetries => attempts < (maxRetries + 1);
 
   Map<String, dynamic> toMap() {

--- a/lib/src/smart_job.dart
+++ b/lib/src/smart_job.dart
@@ -71,8 +71,6 @@ class SmartJob {
   JobFailureCallback? onFailure;
   JobRetryCallback? onRetry;
 
-  bool isExecuting = false;
-
   bool get hasRemainingRetries => attempts < (maxRetries + 1);
 
   Map<String, dynamic> toMap() {

--- a/lib/src/smart_queue.dart
+++ b/lib/src/smart_queue.dart
@@ -186,6 +186,9 @@ class SmartQueue {
 
   Future<void> _runJob(SmartJob job) async {
     if (_disposed || _isExecutingJob(job.id)) return;
+
+    _executingJobIds.add(job.id);
+
     final bool hasSimple = _handlers.containsKey(job.type);
     final bool hasCtx = _ctxHandlers.containsKey(job.type);
     if (!hasSimple && !hasCtx) {
@@ -193,6 +196,7 @@ class SmartQueue {
       job.lastError = 'No handler for type ${job.type}';
       await _store.removeJob(job.id);
       _inFlight.remove(job.id);
+      _executingJobIds.remove(job.id);
       job.onFailure?.call(job, StateError(job.lastError!), StackTrace.current);
       _scheduleWork();
       _tryComplete();

--- a/lib/src/smart_queue.dart
+++ b/lib/src/smart_queue.dart
@@ -253,6 +253,7 @@ class SmartQueue {
         // Re-enqueue with delay
         Timer(delay, () async {
           if (_disposed) return;
+          if ((await _store.getJob(job.id)) == null) return;
           _inFlight.remove(job.id);
           _pending.addLast(job);
           await _store.putJob(job);

--- a/lib/src/smart_queue.dart
+++ b/lib/src/smart_queue.dart
@@ -1,14 +1,14 @@
 import 'dart:async';
 import 'dart:collection';
+import 'dart:math' as math;
 
 import 'package:collection/collection.dart';
 
+import 'dlq/dead_letter_store.dart';
+import 'events/queue_events.dart';
 import 'retry_strategy.dart';
 import 'smart_job.dart';
 import 'storage/queue_store.dart';
-import 'dart:math' as math;
-import 'events/queue_events.dart';
-import 'dlq/dead_letter_store.dart';
 
 /// Runtime configuration for [SmartQueue]. Controls concurrency, retries,
 /// persistence cadence, and multi-instance execution leases.
@@ -84,6 +84,8 @@ class SmartQueue {
   bool _started = false;
   bool _disposed = false;
 
+  Completer<void>? _processingDoneCompleter;
+
   /// True if the queue has started and is not disposed.
   bool get isRunning => _started && !_disposed;
 
@@ -98,13 +100,18 @@ class SmartQueue {
   }
 
   /// Load persisted jobs and begin processing according to config.
-  Future<void> start() async {
-    if (_started) return;
+  Future<void> start({Completer<void>? processingDoneCompleter}) async {
+    _processingDoneCompleter = processingDoneCompleter;
+    if (_started) {
+      _tryComplete();
+      return;
+    }
     _started = true;
     // Load persisted jobs
     final List<SmartJob> jobs = await _store.loadJobs();
     jobs.sortBy((SmartJob j) => j.createdAt);
     _pending.addAll(jobs);
+    _tryComplete();
 
     // Kick off periodic persistence of in-memory queue state
     _persistTimer = Timer.periodic(_config.persistInterval, (_) async {
@@ -177,7 +184,8 @@ class SmartQueue {
   }
 
   Future<void> _runJob(SmartJob job) async {
-    if (_disposed) return;
+    if (_disposed || job.isExecuting) return;
+    job.isExecuting = true;
     final bool hasSimple = _handlers.containsKey(job.type);
     final bool hasCtx = _ctxHandlers.containsKey(job.type);
     if (!hasSimple && !hasCtx) {
@@ -187,6 +195,7 @@ class SmartQueue {
       _inFlight.remove(job.id);
       job.onFailure?.call(job, StateError(job.lastError!), StackTrace.current);
       _scheduleWork();
+      _tryComplete();
       return;
     }
 
@@ -258,8 +267,28 @@ class SmartQueue {
         job.onFailure?.call(job, err, st);
       }
     } finally {
+      job.isExecuting = false;
       // If success path did not schedule more, schedule now
       _scheduleWork();
+      _tryComplete();
+    }
+  }
+
+  Future<void> forceRetry(String jobId) async {
+    if (!_started || _disposed) return;
+    final SmartJob? job =
+        _inFlight[jobId] ?? _pending.firstWhereOrNull((e) => e.id == jobId);
+    if (job != null && !job.isExecuting) {
+      _pending.remove(job);
+      await _runJob(job);
+    }
+  }
+
+  void _tryComplete() {
+    if (_processingDoneCompleter != null &&
+        !_processingDoneCompleter!.isCompleted &&
+        _inFlight.isEmpty && _pending.isEmpty) {
+      _processingDoneCompleter!.complete();
     }
   }
 }

--- a/lib/src/smart_queue.dart
+++ b/lib/src/smart_queue.dart
@@ -71,6 +71,7 @@ class SmartQueue {
   final Queue<SmartJob> _pending = Queue<SmartJob>();
   final Map<String, SmartJob> _inFlight = <String, SmartJob>{};
   final Set<String> _executingJobIds = {};
+  final Map<String, Timer> _retryTimers = {};
 
   final String _ownerId;
   final DeadLetterStore? _dlq;
@@ -126,6 +127,10 @@ class SmartQueue {
   Future<void> dispose() async {
     _disposed = true;
     _persistTimer?.cancel();
+    for (final timer in _retryTimers.values) {
+      timer.cancel();
+    }
+    _retryTimers.clear();
     // No explicit close for store; user manages underlying resources
   }
 
@@ -251,15 +256,17 @@ class SmartQueue {
         job.onRetry?.call(job, job.attempts, delay);
         _events.add(JobRetryScheduled(job, job.attempts, delay));
         // Re-enqueue with delay
-        Timer(delay, () async {
+        _retryTimers[job.id]?.cancel();
+        final timer = Timer(delay, () async {
           if (_disposed) return;
-          if ((await _store.getJob(job.id)) == null) return;
+          _retryTimers.remove(job.id);
           _inFlight.remove(job.id);
           _pending.addLast(job);
           await _store.putJob(job);
           // Immediately attempt to run next available job (prevents idle at concurrency=1)
           _scheduleWork();
         });
+        _retryTimers[job.id] = timer;
       } else {
         // Exhausted
         await _store.removeJob(job.id);
@@ -286,6 +293,7 @@ class SmartQueue {
     final SmartJob? job =
         _inFlight[jobId] ?? _pending.firstWhereOrNull((e) => e.id == jobId);
     if (job != null) {
+      _retryTimers[job.id]?.cancel();
       _pending.remove(job);
       await _runJob(job);
     }

--- a/lib/src/smart_queue.dart
+++ b/lib/src/smart_queue.dart
@@ -70,6 +70,7 @@ class SmartQueue {
       <String, JobHandlerWithContext>{};
   final Queue<SmartJob> _pending = Queue<SmartJob>();
   final Map<String, SmartJob> _inFlight = <String, SmartJob>{};
+  final Set<String> _executingJobIds = {};
 
   final String _ownerId;
   final DeadLetterStore? _dlq;
@@ -184,8 +185,7 @@ class SmartQueue {
   }
 
   Future<void> _runJob(SmartJob job) async {
-    if (_disposed || job.isExecuting) return;
-    job.isExecuting = true;
+    if (_disposed || _isExecutingJob(job.id)) return;
     final bool hasSimple = _handlers.containsKey(job.type);
     final bool hasCtx = _ctxHandlers.containsKey(job.type);
     if (!hasSimple && !hasCtx) {
@@ -216,6 +216,8 @@ class SmartQueue {
         _scheduleWork();
         return;
       }
+
+      _executingJobIds.add(job.id);
 
       final JobHandler? handler = _handlers[job.type];
       final JobHandlerWithContext? ctx = _ctxHandlers[job.type];
@@ -267,7 +269,7 @@ class SmartQueue {
         job.onFailure?.call(job, err, st);
       }
     } finally {
-      job.isExecuting = false;
+      _executingJobIds.remove(job.id);
       // If success path did not schedule more, schedule now
       _scheduleWork();
       _tryComplete();
@@ -275,13 +277,17 @@ class SmartQueue {
   }
 
   Future<void> forceRetry(String jobId) async {
-    if (!_started || _disposed) return;
+    if (!_started || _disposed || _isExecutingJob(jobId)) return;
     final SmartJob? job =
         _inFlight[jobId] ?? _pending.firstWhereOrNull((e) => e.id == jobId);
-    if (job != null && !job.isExecuting) {
+    if (job != null) {
       _pending.remove(job);
       await _runJob(job);
     }
+  }
+  
+  bool _isExecutingJob(String jobId) {
+    return _executingJobIds.contains(jobId);
   }
 
   void _tryComplete() {

--- a/lib/src/smart_queue.dart
+++ b/lib/src/smart_queue.dart
@@ -50,27 +50,24 @@ class SmartQueue {
     SmartQueueConfig config = const SmartQueueConfig(),
     Map<String, JobHandler>? handlers,
     DeadLetterStore? deadLetterStore,
-  })
-      : _store = store,
-        _config = config,
-        _ownerId = config.ownerId ?? _generateOwnerId(),
-        _dlq = deadLetterStore {
+  }) : _store = store,
+       _config = config,
+       _ownerId = config.ownerId ?? _generateOwnerId(),
+       _dlq = deadLetterStore {
     if (handlers != null) {
       _handlers.addAll(handlers);
     }
   }
 
   static String _generateOwnerId() =>
-      '${DateTime
-          .now()
-          .millisecondsSinceEpoch}-${math.Random().nextInt(1 << 32)}';
+      '${DateTime.now().millisecondsSinceEpoch}-${math.Random().nextInt(1 << 32)}';
 
   final QueueStore _store;
   final SmartQueueConfig _config;
 
   final Map<String, JobHandler> _handlers = <String, JobHandler>{};
   final Map<String, JobHandlerWithContext> _ctxHandlers =
-  <String, JobHandlerWithContext>{};
+      <String, JobHandlerWithContext>{};
   final Queue<SmartJob> _pending = Queue<SmartJob>();
   final Map<String, SmartJob> _inFlight = <String, SmartJob>{};
   final Set<String> _executingJobIds = {};
@@ -80,7 +77,7 @@ class SmartQueue {
   final DeadLetterStore? _dlq;
 
   final StreamController<QueueEvent> _events =
-  StreamController<QueueEvent>.broadcast();
+      StreamController<QueueEvent>.broadcast();
 
   /// Stream of lifecycle events for observability and UI.
   Stream<QueueEvent> get events => _events.stream;
@@ -190,7 +187,7 @@ class SmartQueue {
     if (_pending.isEmpty) return null;
     final DateTime now = DateTime.now();
     final Iterable<SmartJob> runnable = _pending.where(
-          (SmartJob j) => j.scheduledAt == null || !j.scheduledAt!.isAfter(now),
+      (SmartJob j) => j.scheduledAt == null || !j.scheduledAt!.isAfter(now),
     );
     if (runnable.isEmpty) return null;
     SmartJob? best;
@@ -299,7 +296,7 @@ class SmartQueue {
     } finally {
       _executingJobIds.remove(job.id);
       // If success path did not schedule more, schedule now
-      _scheduleWork();
+      Future.delayed(const Duration(milliseconds: 100), () => _scheduleWork());
       _tryComplete();
     }
   }
@@ -322,7 +319,8 @@ class SmartQueue {
   void _tryComplete() {
     if (_processingDoneCompleter != null &&
         !_processingDoneCompleter!.isCompleted &&
-        _inFlight.isEmpty && _pending.isEmpty) {
+        _inFlight.isEmpty &&
+        _pending.isEmpty) {
       _processingDoneCompleter!.complete();
     }
   }

--- a/lib/src/smart_queue.dart
+++ b/lib/src/smart_queue.dart
@@ -50,24 +50,27 @@ class SmartQueue {
     SmartQueueConfig config = const SmartQueueConfig(),
     Map<String, JobHandler>? handlers,
     DeadLetterStore? deadLetterStore,
-  }) : _store = store,
-       _config = config,
-       _ownerId = config.ownerId ?? _generateOwnerId(),
-       _dlq = deadLetterStore {
+  })
+      : _store = store,
+        _config = config,
+        _ownerId = config.ownerId ?? _generateOwnerId(),
+        _dlq = deadLetterStore {
     if (handlers != null) {
       _handlers.addAll(handlers);
     }
   }
 
   static String _generateOwnerId() =>
-      '${DateTime.now().millisecondsSinceEpoch}-${math.Random().nextInt(1 << 32)}';
+      '${DateTime
+          .now()
+          .millisecondsSinceEpoch}-${math.Random().nextInt(1 << 32)}';
 
   final QueueStore _store;
   final SmartQueueConfig _config;
 
   final Map<String, JobHandler> _handlers = <String, JobHandler>{};
   final Map<String, JobHandlerWithContext> _ctxHandlers =
-      <String, JobHandlerWithContext>{};
+  <String, JobHandlerWithContext>{};
   final Queue<SmartJob> _pending = Queue<SmartJob>();
   final Map<String, SmartJob> _inFlight = <String, SmartJob>{};
   final Set<String> _executingJobIds = {};
@@ -77,7 +80,7 @@ class SmartQueue {
   final DeadLetterStore? _dlq;
 
   final StreamController<QueueEvent> _events =
-      StreamController<QueueEvent>.broadcast();
+  StreamController<QueueEvent>.broadcast();
 
   /// Stream of lifecycle events for observability and UI.
   Stream<QueueEvent> get events => _events.stream;
@@ -85,6 +88,7 @@ class SmartQueue {
   Timer? _persistTimer;
   bool _started = false;
   bool _disposed = false;
+  bool _isScheduling = false;
 
   Completer<void>? _processingDoneCompleter;
 
@@ -162,20 +166,31 @@ class SmartQueue {
 
   void _scheduleWork() {
     if (!_started || _disposed) return;
-    // Run as many as allowed by concurrency with basic scheduling
-    while (_inFlight.length < _config.concurrency && _pending.isNotEmpty) {
-      final SmartJob? next = _selectNextJob();
-      if (next == null) break;
-      // Start immediately so _inFlight updates before next iteration
-      _runJob(next);
-    }
+    if (_isScheduling) return;
+
+    Future.microtask(() async {
+      try {
+        if (_isScheduling) return;
+        _isScheduling = true;
+
+        // Run as many as allowed by concurrency with basic scheduling
+        while (_inFlight.length < _config.concurrency && _pending.isNotEmpty) {
+          final SmartJob? next = _selectNextJob();
+          if (next == null) break;
+          // Start immediately so _inFlight updates before next iteration
+          _runJob(next);
+        }
+      } finally {
+        _isScheduling = false;
+      }
+    });
   }
 
   SmartJob? _selectNextJob() {
     if (_pending.isEmpty) return null;
     final DateTime now = DateTime.now();
     final Iterable<SmartJob> runnable = _pending.where(
-      (SmartJob j) => j.scheduledAt == null || !j.scheduledAt!.isAfter(now),
+          (SmartJob j) => j.scheduledAt == null || !j.scheduledAt!.isAfter(now),
     );
     if (runnable.isEmpty) return null;
     SmartJob? best;
@@ -203,7 +218,6 @@ class SmartQueue {
       _inFlight.remove(job.id);
       _executingJobIds.remove(job.id);
       job.onFailure?.call(job, StateError(job.lastError!), StackTrace.current);
-      _scheduleWork();
       _tryComplete();
       return;
     }
@@ -218,11 +232,13 @@ class SmartQueue {
         _ownerId,
         _config.leaseTtl,
       );
+      final existJob = await _store.existJob(job.id);
       if (!leased) {
         _inFlight.remove(job.id);
         // Put at tail to avoid tight retry loop under contention
-        _pending.add(job);
-        _scheduleWork();
+        if (existJob) {
+          _pending.add(job);
+        }
         return;
       }
 
@@ -298,7 +314,7 @@ class SmartQueue {
       await _runJob(job);
     }
   }
-  
+
   bool _isExecutingJob(String jobId) {
     return _executingJobIds.contains(jobId);
   }

--- a/lib/src/storage/hive_store.dart
+++ b/lib/src/storage/hive_store.dart
@@ -49,6 +49,18 @@ class HiveStore implements QueueStore {
   }
 
   @override
+  Future<SmartJob?> getJob(String id) async {
+    final Box<Map<dynamic, dynamic>> box = await _openBox();
+    final Map<dynamic, dynamic>? data = box.get(id);
+
+    if (data == null) {
+      return null;
+    }
+
+    return SmartJob.fromMap(data);
+  }
+
+  @override
   Future<bool> tryAcquireLease(String id, String ownerId, Duration ttl) async {
     final Box<Map<dynamic, dynamic>> box = await _openBox();
     final Map<dynamic, dynamic>? existing = box.get(id);

--- a/lib/src/storage/hive_store.dart
+++ b/lib/src/storage/hive_store.dart
@@ -61,6 +61,14 @@ class HiveStore implements QueueStore {
   }
 
   @override
+  Future<bool> existJob(String id) async {
+    final Box<Map<dynamic, dynamic>> box = await _openBox();
+    final Map<dynamic, dynamic>? data = box.get(id);
+
+    return data != null;
+  }
+
+  @override
   Future<bool> tryAcquireLease(String id, String ownerId, Duration ttl) async {
     final Box<Map<dynamic, dynamic>> box = await _openBox();
     final Map<dynamic, dynamic>? existing = box.get(id);

--- a/lib/src/storage/hive_store.dart
+++ b/lib/src/storage/hive_store.dart
@@ -104,4 +104,12 @@ class HiveStore implements QueueStore {
       await box.put(id, existing.cast<String, dynamic>());
     }
   }
+
+  @override
+  Future<void> close() async {
+    if (_box?.isOpen == true) {
+      await _box?.flush();
+      await _box?.close();
+    }
+  }
 }

--- a/lib/src/storage/memory_store.dart
+++ b/lib/src/storage/memory_store.dart
@@ -42,6 +42,12 @@ class MemoryStore implements QueueStore {
   }
 
   @override
+  Future<bool> existJob(String id) async {
+    final int index = _jobs.indexWhere((SmartJob j) => j.id == id);
+    return index >= 0;
+  }
+
+  @override
   Future<bool> tryAcquireLease(String id, String ownerId, Duration ttl) async {
     final int idx = _jobs.indexWhere((SmartJob j) => j.id == id);
     if (idx < 0) return false;

--- a/lib/src/storage/memory_store.dart
+++ b/lib/src/storage/memory_store.dart
@@ -82,4 +82,8 @@ class MemoryStore implements QueueStore {
       _jobs[idx] = job;
     }
   }
+
+  @override
+  Future<void> close() async {
+  }
 }

--- a/lib/src/storage/memory_store.dart
+++ b/lib/src/storage/memory_store.dart
@@ -33,6 +33,15 @@ class MemoryStore implements QueueStore {
   }
 
   @override
+  Future<SmartJob?> getJob(String id) async {
+    final int index = _jobs.indexWhere((SmartJob j) => j.id == id);
+    if (index < 0) {
+      return null;
+    }
+    return _jobs[index];
+  }
+
+  @override
   Future<bool> tryAcquireLease(String id, String ownerId, Duration ttl) async {
     final int idx = _jobs.indexWhere((SmartJob j) => j.id == id);
     if (idx < 0) return false;

--- a/lib/src/storage/queue_store.dart
+++ b/lib/src/storage/queue_store.dart
@@ -5,6 +5,7 @@ abstract class QueueStore {
   Future<void> putJob(SmartJob job);
   Future<void> removeJob(String id);
   Future<SmartJob?> getJob(String id);
+  Future<bool> existJob(String id);
   Future<void> clear();
 
   /// Try to acquire a short-lived lease for [id]. Returns true if acquired.

--- a/lib/src/storage/queue_store.dart
+++ b/lib/src/storage/queue_store.dart
@@ -4,6 +4,7 @@ abstract class QueueStore {
   Future<List<SmartJob>> loadJobs();
   Future<void> putJob(SmartJob job);
   Future<void> removeJob(String id);
+  Future<SmartJob?> getJob(String id);
   Future<void> clear();
 
   /// Try to acquire a short-lived lease for [id]. Returns true if acquired.

--- a/lib/src/storage/queue_store.dart
+++ b/lib/src/storage/queue_store.dart
@@ -7,6 +7,7 @@ abstract class QueueStore {
   Future<SmartJob?> getJob(String id);
   Future<bool> existJob(String id);
   Future<void> clear();
+  Future<void> close();
 
   /// Try to acquire a short-lived lease for [id]. Returns true if acquired.
   Future<bool> tryAcquireLease(String id, String ownerId, Duration ttl) async =>

--- a/test/test_smart_queue.dart
+++ b/test/test_smart_queue.dart
@@ -91,4 +91,46 @@ void main() {
     expect(events.where((s) => s.startsWith('enq:')).toList().length, 2);
     expect(events.where((s) => s.startsWith('ok:')).toList().length, 2);
   });
+
+  test('same job cannot execute concurrently', () async {
+    final store = MemoryStore();
+
+    final queue = SmartQueue(
+      store: store,
+      config: const SmartQueueConfig(concurrency: 2),
+    );
+
+    int concurrentExecutions = 0;
+    int maxConcurrentExecutions = 0;
+
+    queue.registerHandler('test', (_) async {
+      concurrentExecutions++;
+      maxConcurrentExecutions = maxConcurrentExecutions > concurrentExecutions ? maxConcurrentExecutions : concurrentExecutions;
+
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      concurrentExecutions--;
+    });
+
+    final job = SmartJob(
+      id: 'job-1',
+      type: 'test',
+      payload: null,
+      maxRetries: 0,
+    );
+
+    await queue.start();
+    await queue.add(job);
+
+    queue.forceRetry(job.id);
+    queue.forceRetry(job.id);
+
+    await Future<void>.delayed(const Duration(milliseconds: 300));
+
+    expect(
+      maxConcurrentExecutions,
+      equals(1),
+      reason: 'The same job must never be executed concurrently',
+    );
+  });
 }

--- a/test/test_smart_queue.dart
+++ b/test/test_smart_queue.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
-import 'package:test/test.dart';
 import 'package:smart_queue/smart_queue.dart';
+import 'package:test/test.dart';
 
 void main() {
   test('executes jobs and persists state', () async {
@@ -103,13 +103,23 @@ void main() {
     int concurrentExecutions = 0;
     int maxConcurrentExecutions = 0;
 
+    final completer = Completer<void>();
+
     queue.registerHandler('test', (_) async {
       concurrentExecutions++;
-      maxConcurrentExecutions = maxConcurrentExecutions > concurrentExecutions ? maxConcurrentExecutions : concurrentExecutions;
+      maxConcurrentExecutions = concurrentExecutions > maxConcurrentExecutions
+          ? concurrentExecutions
+          : maxConcurrentExecutions;
 
       await Future<void>.delayed(const Duration(milliseconds: 100));
 
       concurrentExecutions--;
+    });
+
+    queue.events.listen((event) {
+      if (event is JobSucceeded) {
+        completer.complete();
+      }
     });
 
     final job = SmartJob(
@@ -125,12 +135,64 @@ void main() {
     queue.forceRetry(job.id);
     queue.forceRetry(job.id);
 
-    await Future<void>.delayed(const Duration(milliseconds: 300));
+    await completer.future;
 
     expect(
       maxConcurrentExecutions,
-      equals(1),
+      1,
       reason: 'The same job must never be executed concurrently',
+    );
+  });
+
+  test('forceRetry can duplicate execution with async store', () async {
+    final store = MemoryStore();
+
+    final queue = SmartQueue(
+      store: store,
+      config: const SmartQueueConfig(
+        concurrency: 1,
+        retryStrategy: FixedRetryStrategy(Duration(milliseconds: 50)),
+      ),
+    );
+
+    int attempt = 0;
+    int succeededJobs = 0;
+
+    final retryScheduled = Completer<void>();
+
+    queue.registerHandler('test', (_) async {
+      attempt++;
+      if (attempt == 1) {
+        throw Exception('fail first attempt');
+      }
+      await Future.delayed(const Duration(milliseconds: 5));
+    });
+
+    queue.events.listen((event) {
+      if (event is JobRetryScheduled) {
+        retryScheduled.complete();
+      }
+      if (event is JobSucceeded) {
+        succeededJobs++;
+      }
+    });
+
+    final job = SmartJob(id: 'job-1', type: 'test', maxRetries: 2);
+
+    await queue.start();
+    await queue.add(job);
+
+    await retryScheduled.future;
+
+    await queue.forceRetry(job.id);
+
+    await Future.delayed(const Duration(milliseconds: 100));
+
+    expect(
+      succeededJobs,
+      1,
+      reason:
+          'Job must succeed exactly once even if forceRetry is called while retry timer is pending',
     );
   });
 }

--- a/test/test_smart_queue.dart
+++ b/test/test_smart_queue.dart
@@ -1,5 +1,8 @@
 import 'dart:async';
+import 'dart:io';
+import 'dart:isolate';
 
+import 'package:hive/hive.dart';
 import 'package:smart_queue/smart_queue.dart';
 import 'package:test/test.dart';
 
@@ -194,5 +197,195 @@ void main() {
       reason:
           'Job must succeed exactly once even if forceRetry is called while retry timer is pending',
     );
+  });
+
+  Future<SmartQueue> initSmartQueue(Map<String, dynamic> args) async {
+    final String ownerId = args['ownerId'];
+    final SendPort sendPort = args['sendPort'];
+    final DateTime startTime = args['startTime'];
+    final HiveStore store = args['store'];
+
+    print('init [$ownerId] store size: ${(await store.loadJobs()).length}');
+
+    final queue = SmartQueue(
+      store: store,
+      config: SmartQueueConfig(
+        concurrency: 1,
+        ownerId: ownerId,
+        retryStrategy: FixedRetryStrategy(Duration(milliseconds: 100)),
+      ),
+    );
+
+    queue.registerHandler('job', (payload) async {
+      int difference = DateTime.now().difference(startTime).inMilliseconds;
+      if (ownerId == 'A' && difference <= 1000) {
+        throw Exception('Planed exception $difference');
+      }
+      await Future.delayed(const Duration(milliseconds: 90));
+      sendPort.send(payload['id'] as String);
+    });
+
+    queue.events.listen((event) {
+      switch (event) {
+        case JobEnqueued(:final job) ||
+            JobStarted(:final job) ||
+            JobProgress(:final job) ||
+            JobRetryScheduled(:final job) ||
+            JobSucceeded(:final job) ||
+            JobFailed(:final job) ||
+            JobDeadLettered(:final job):
+          print(
+            '[SmartQueue] ${event.runtimeType} '
+            'jobId: ${job.id}, '
+            'queue size: ${queue.length}',
+          );
+      }
+    });
+
+    await queue.start();
+
+    return queue;
+  }
+
+  Future<void> queueAIsolateEntry(Map<String, dynamic> args) async {
+    final String ownerId = args['ownerId'];
+    final SendPort sendPort = args['sendPort'];
+    final List<SmartJob>? jobs = args['jobs'];
+    final String dbPath = args['dbPath'];
+    final store = HiveStore(boxName: 'jobs');
+    Directory(dbPath).createSync(recursive: true);
+    Hive.init(dbPath);
+    args['store'] = store;
+
+    SmartQueue? queue;
+
+    final commandPort = ReceivePort();
+    sendPort.send(commandPort.sendPort);
+
+    commandPort.listen((message) async {
+      print('lifecycle $ownerId is $message');
+
+      if (message == 'pause' && queue != null) {
+        print('dispose $ownerId SmartQueue');
+        await queue?.dispose();
+        await store.close();
+      }
+      if (message == 'resume') {
+        queue = await initSmartQueue(args);
+      }
+      if (message == 'addjobs') {
+        print('add jobs');
+        if (jobs != null) {
+          for (final job in jobs) {
+            await queue?.add(job);
+          }
+        }
+      }
+    });
+  }
+
+  Future<void> queueBIsolateEntry(Map<String, dynamic> args) async {
+    final String ownerId = args['ownerId'];
+    final SendPort sendPort = args['sendPort'];
+    final String dbPath = args['dbPath'];
+    final store = HiveStore(boxName: 'jobs');
+    Directory(dbPath).createSync(recursive: true);
+    Hive.init(dbPath);
+    args['store'] = store;
+
+    SmartQueue? queue;
+
+    final commandPort = ReceivePort();
+    sendPort.send(commandPort.sendPort);
+
+    commandPort.listen((message) async {
+      print('lifecycle $ownerId is $message');
+
+      if (message == 'pause' && queue != null) {
+        print('dispose $ownerId SmartQueue');
+        await queue?.dispose();
+        await store.close();
+      }
+      if (message == 'resume') {
+        queue = await initSmartQueue(args);
+      }
+    });
+  }
+
+  test('race condition with two isolates', () async {
+    final String dbPath = './hive_test/hive';
+
+    final List<SmartJob> jobs = List.generate(
+      10,
+      (i) => SmartJob(
+        id: 'job-$i',
+        type: 'job',
+        payload: {'id': 'job-$i'},
+        maxRetries: 100,
+      ),
+    );
+
+    final receivePortA = ReceivePort();
+    final receivePortB = ReceivePort();
+    SendPort? commandPortA;
+    SendPort? commandPortB;
+    final processedJobs = <String>[];
+
+    receivePortA.listen((message) {
+      if (message is String) processedJobs.add(message);
+      if (message is SendPort) commandPortA = message;
+    });
+    receivePortB.listen((message) {
+      if (message is String) processedJobs.add(message);
+      if (message is SendPort) commandPortB = message;
+    });
+
+    final isolateA = await Isolate.spawn(queueAIsolateEntry, {
+      'ownerId': 'A',
+      'sendPort': receivePortA.sendPort,
+      'jobs': jobs,
+      'dbPath': dbPath,
+      'startTime': DateTime.now(),
+    });
+    await Future.delayed(const Duration(milliseconds: 100));
+    commandPortA?.send('resume');
+    await Future.delayed(const Duration(milliseconds: 100));
+    commandPortA?.send('addjobs');
+    await Future.delayed(const Duration(milliseconds: 1000));
+    commandPortA?.send('pause');
+    await Future.delayed(const Duration(milliseconds: 500));
+
+    final isolateB = await Isolate.spawn(queueBIsolateEntry, {
+      'ownerId': 'B',
+      'sendPort': receivePortB.sendPort,
+      'dbPath': dbPath,
+      'producer': false,
+      'startTime': DateTime.now(),
+    });
+    await Future.delayed(const Duration(milliseconds: 100));
+    commandPortB?.send('resume');
+    await Future.delayed(const Duration(milliseconds: 500));
+    commandPortB?.send('pause');
+    await Future.delayed(const Duration(milliseconds: 500));
+    print('kill B isolate');
+    isolateB.kill(priority: Isolate.immediate);
+
+    await Future.delayed(const Duration(milliseconds: 100));
+    commandPortA?.send('resume');
+
+    await Future<void>.delayed(const Duration(seconds: 5));
+
+    receivePortA.close();
+    receivePortB.close();
+    isolateA.kill(priority: Isolate.immediate);
+
+    expect(
+      processedJobs.length,
+      10,
+      reason:
+          'Race condition detected: some jobs may have been processed by both queues',
+    );
+
+    print('Processed jobs: $processedJobs');
   });
 }


### PR DESCRIPTION
Summary

This change extends the SmartQueue to support more explicit and controllable job execution, both from the UI layer and from background contexts.

Key changes

Added forceRetry(String jobId) to SmartQueue
Enables forcing an immediate re-processing of a specific job as a direct result of user interaction (e.g. from the UI), without restarting the entire queue. This makes manual recovery and user-triggered retries predictable and explicit.

Extended SmartQueue.start() with processingDoneCompleter

Future<void> start({Completer<void>? processingDoneCompleter})


The optional completer is completed once all pending and in-flight jobs have finished processing. This allows callers to deterministically await queue completion, which is particularly useful in time-constrained execution environments.

Track currently executing jobs in SmartQueue using an internal set to prevent duplicate execution and ensure safe retry and force-retry behavior.

Rationale

These changes improve control and observability over job execution by:

Allowing user-driven, immediate retries from the UI

Preventing concurrent execution of the same job

Making queue completion explicitly awaitable

Supporting clean integration with constrained execution contexts without coupling core logic to them

Behavioural impact

Existing usage of SmartQueue.start() remains unchanged when the completer is not provided.

No changes to job ordering or persistence behaviour.

Improves reliability and debuggability of manual retry flows.